### PR TITLE
fix: include and exclude the correct files for publishing to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# .pref
+# .pref (beta)
 
 > Perfect for CLI application user preferences
 
-Out of the 📦⤵️ easy application encrypted preferences 👍 customize when necessary 🎨⚙️.
+Out of the box 📦⤵️ easy application encrypted preferences 👍
 
 ---
+
+**_This is a beta release so the API could change without warning._**
 
 ## Highlights
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dotpref",
   "version": "0.0.0-development",
-  "description": "Manage CLI application encrypted preferences in a stateful way.",
+  "description": "Perfect for CLI application user preferences.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -38,5 +38,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/cassels/dotpref.git"
-  }
+  },
+  "files": [
+    "lib",
+    "yarn.lock"
+  ]
 }


### PR DESCRIPTION
Add `lib, yarn.lock` to `package.json`'s `files` property to ensure the correct files are being published.
Some small modifications to the README.md as well.