### PR TITLE
chore(release): update release config for debugging

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,14 +1,17 @@
 branches:
   - master
 plugins:
-- - "@semantic-release/commit-analyzer"
-  - releaseRules:
-    - type: docs
-      scope: README
-      release: patch
-    - type: chore
-      scope: deps
-      release: patch
-- "@semantic-release/release-notes-generator"
-- "@semantic-release/npm"
-- "@semantic-release/github"
+  - - '@semantic-release/commit-analyzer'
+    - releaseRules:
+        - type: docs
+          scope: README
+          release: patch
+        - type: chore
+          scope: deps
+          release: patch
+        - type: chore
+          scope: release
+          release: patch
+  - '@semantic-release/release-notes-generator'
+  - '@semantic-release/npm'
+  - '@semantic-release/github'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "yarn clean && tsc",
     "build:watch": "tsc --watch ",
     "clean": "rm -rf lib",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release --dry-run=$SEMANTIC_RELEASE_DRYRUN"
   },
   "keywords": [
     "pref",


### PR DESCRIPTION
- Adding a `dry-run` flag for better debugging visibility into semantic-release.
- Adding a release config to ensure commits with type and scope `chore(release)` will trigger a release.