### PR TITLE
chore(workflow): compatibility changes for GH action v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,10 @@ jobs:
       - run: yarn install
 
       - name: Download lib
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: lib
+          path: lib
 
       - name: Check Files
         uses: JJ/files-present-action@releases/v1


### PR DESCRIPTION
Following the [migration path for v1 to v2](https://github.com/actions/download-artifact#compatibility-between-v1-and-v2v3) that was missing from the [download artifact release notes](https://github.com/actions/download-artifact/releases/tag/v2.0.1) that should hopefully provide backwards compatibility for v3. This should resolve #294. 